### PR TITLE
Remove AAS journal info

### DIFF
--- a/joss/paper.md
+++ b/joss/paper.md
@@ -23,10 +23,6 @@ affiliations:
 date: 01 June 2024
 bibliography: paper.bib
 
-# Optional fields if submitting to a AAS journal too, see this blog post:
-# https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
-aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
-aas-journal: Astrophysical Journal <- The name of the AAS journal.
 ---
 
 


### PR DESCRIPTION
Just notices that the joint submission info for the AAS journal is still there. My apologies, I should have noticed earlier.